### PR TITLE
Downgrade to version .Net8

### DIFF
--- a/.github/workflows/deploy-to-nuget.yml
+++ b/.github/workflows/deploy-to-nuget.yml
@@ -19,15 +19,15 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.0 # Use .NET 9
+        dotnet-version: 8.0 # Use .NET 8
 
     # Restore dependencies
     - name: Restore dependencies
-      run: dotnet restore ./src/PackedTables/PackedTables.sln
+      run: dotnet restore ./PackedTables.sln
 
     # Clean solution
     - name: Clean solution
-      run: dotnet clean ./src/PackedTables/PackedTables.sln
+      run: dotnet clean ./PackedTables.sln
 
     # Ensure artifacts directory exists
     - name: Create artifacts directory
@@ -35,7 +35,7 @@ jobs:
 
     # Build the project
     - name: Build
-      run: dotnet build ./src/PackedTables/PackedTables.sln --configuration Release --no-restore
+      run: dotnet build ./PackedTables.sln --configuration Release --no-restore
 
     # Run tests
     - name: Run tests
@@ -43,7 +43,7 @@ jobs:
 
     # Pack the project
     - name: Pack
-      run: dotnet pack ./src/PackedTables/PackedTables.sln --configuration Release --no-build --output ./artifacts
+      run: dotnet pack ./PackedTables.sln --configuration Release --no-build --output ./artifacts
             
     - name: Verify artifacts directory
       run: ls -la ./artifacts

--- a/PackedTables.sln
+++ b/PackedTables.sln
@@ -3,14 +3,14 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackedTables", "PackedTables.csproj", "{0DECF966-2649-4A7E-AE23-2CB11BB9DB9D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackedTables", "src\PackedTables\PackedTables.csproj", "{0DECF966-2649-4A7E-AE23-2CB11BB9DB9D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackedTables.Tests", "..\PackedTables.Tests\PackedTables.Tests.csproj", "{6EA43261-6071-4D8A-8332-913443C2B8B3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackedTables.Tests", "src\PackedTables.Tests\PackedTables.Tests.csproj", "{6EA43261-6071-4D8A-8332-913443C2B8B3}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
-		..\..\LICENSE = ..\..\LICENSE
-		..\..\README.md = ..\..\README.md
+		LICENSE = LICENSE
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global
@@ -26,7 +26,7 @@ Global
 		{6EA43261-6071-4D8A-8332-913443C2B8B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6EA43261-6071-4D8A-8332-913443C2B8B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6EA43261-6071-4D8A-8332-913443C2B8B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6EA43261-6071-4D8A-8332-913443C2B8B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EA43261-6071-4D8A-8332-913443C2B8B3}.Release|Any CPU.Build.0 = Release|Any CPU		
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/PackedTables.Tests/PackedTables.Tests.csproj
+++ b/src/PackedTables.Tests/PackedTables.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSTest.Sdk/3.6.4">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/PackedTables/PackedTables.csproj
+++ b/src/PackedTables/PackedTables.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ApplicationIcon>flame.ico</ApplicationIcon>    
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/mmeents/PackedTables.NET</PackageProjectUrl>    
     <PackageTags>MessagePack Tables</PackageTags>    
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>PackedTables.NET</Title>
     <Authors>$(AssemblyName)</Authors>
     <Copyright> Copyright © 2025 MattMeents</Copyright>


### PR DESCRIPTION
relocates solution to root.  updates cicd to look for solution at root.